### PR TITLE
Update recipe for py312_patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - wheel
   run:
     - python
-    - ipython >=8.14.0
+    - ipython >=7.14.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "line_profiler" %}
-{% set version = "4.0.3" %}
+{% set version = "4.1.1" %}
 
 package:
   name: {{ name }}
@@ -8,36 +8,28 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: deb2eb9e9119d911debe23edcec8ea68a2cd70c9e3f753c96aaf4a86ca497e7e
+  sha256: 2fa73d2ac736902e0a6d1e74cf663244218d9c238a7aa5b5acfd6ac6d4672830
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<36]
-  script:
-    # We can't use CMAKE_GENERATOR implicitly via conda_build_config.yaml, yet,
-    # due to https://github.com/AnacondaRecipes/aggregate/pull/182
-    - set "CMAKE_GENERATOR=Ninja"  # [win]
-    - export CMAKE_GENERATOR=Ninja  # [not (win or (osx and arm64))]
-    - export CMAKE_OSX_ARCHITECTURES="arm64"  # [osx and arm64]
-    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - kernprof = kernprof:main
 
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - cmake
-    - ninja
   host:
     - python
     - pip
-    - cython 0.29
-    - scikit-build 0.15.0
+    - cython 0.29 # [py<312]
+    - cython 3.0  # [py>=312]
     - setuptools
     - wheel
   run:
     - python
-    - ipython >=0.13
+    - ipython >=8.14.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: deb2eb9e9119d911debe23edcec8ea68a2cd70c9e3f753c96aaf4a86ca497e7e
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<36]
   script:
     # We can't use CMAKE_GENERATOR implicitly via conda_build_config.yaml, yet,
@@ -31,7 +31,7 @@ requirements:
   host:
     - python
     - pip
-    - cython 0.29.33
+    - cython 0.29
     - scikit-build 0.15.0
     - setuptools
     - wheel


### PR DESCRIPTION
Preparation for py312 release.

Update to 4.1.1
Removed scikit-build as it is a fallback for when cython is not available.