### PR TITLE
[PKG-6542] Update to 4.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "line_profiler" %}
-{% set version = "4.1.1" %}
+{% set version = "4.2.0" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2fa73d2ac736902e0a6d1e74cf663244218d9c238a7aa5b5acfd6ac6d4672830
+  sha256: 09e10f25f876514380b3faee6de93fb0c228abba85820ba1a591ddb3eb451a96
 
 build:
   number: 0
@@ -23,13 +23,16 @@ requirements:
   host:
     - python
     - pip
-    - cython 0.29 # [py<312]
-    - cython 3.0  # [py>=312]
-    - setuptools
+    - cython >=3.0.3
+    - setuptools >=68.2.2
     - wheel
   run:
     - python
-    - ipython >=7.14.0
+  run_constrained:
+    - ipython >=8.14.0  # [py>=39]
+    - ipython >=8.12.2  # [py==38]
+    - ipython >=7.18.0  # [py==37]
+    - ipython >=7.14.0  # [py==36]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,15 +35,20 @@ requirements:
     - ipython >=7.14.0  # [py==36]
 
 test:
+  source_files:
+    - tests
   imports:
     - kernprof
     - line_profiler
   requires:
     - pip
+    - pytest
   commands:
     - pip check
     - kernprof --help
     - python -m kernprof --help
+    # Ignored tests require ubelt
+    - pytest --ignore=tests/test_autoprofile.py --ignore=tests/test_complex_case.py --ignore=tests/test_explicit_profile.py --ignore=tests/test_cli.py
 
 about:
   home: https://github.com/pyutils/line_profiler


### PR DESCRIPTION
line_profiler 4.2.0 

**Destination channel:** defaults

### Links

- [PKG-6542]
- [Upstream repository](https://github.com/pyutils/line_profiler)
- [Upstream changelog/diff](https://github.com/pyutils/line_profiler/blob/v4.2.0/CHANGELOG.rst)

### Explanation of changes:

- Added upstream tests
- Moved `ipython` to run_constrained to match upstream requirements.


[PKG-6542]: https://anaconda.atlassian.net/browse/PKG-6542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ